### PR TITLE
Update with additional paths for searching in Linux

### DIFF
--- a/opuslib_next/api/__init__.py
+++ b/opuslib_next/api/__init__.py
@@ -10,29 +10,38 @@ import os
 import platform
 from ctypes.util import find_library  # type: ignore
 
-__author__ = 'kalicyh <kalicyh@qq.com>'
-__copyright__ = 'Copyright (c) 2025, Kalicyh'
-__license__ = 'BSD 3-Clause License'
+__author__ = "kalicyh <kalicyh@qq.com>"
+__copyright__ = "Copyright (c) 2025, Kalicyh"
+__license__ = "BSD 3-Clause License"
 
 
-lib_location = find_library('opus')
+lib_location = find_library("opus")
 
 if lib_location is None:
     # find opus library in macOS
-    if platform.system() == 'Darwin':
+    if platform.system() == "Darwin":
         lib_paths = [
-            '/opt/homebrew/lib/libopus.dylib',
-            '/usr/local/lib/libopus.dylib',
+            "/opt/homebrew/lib/libopus.dylib",
+            "/usr/local/lib/libopus.dylib",
         ]
-        
+
         for path in lib_paths:
             if os.path.exists(path):
                 lib_location = path
                 break
-    
+    # additional paths for Linux
+    elif platform.system() == "Linux":
+        lib_paths = [
+            "/usr/lib/x86_64-linux-gnu/libopus.so.0",
+            "/usr/local/lib/libopus.so.0",
+        ]
+        for path in lib_paths:
+            if os.path.exists(path):
+                lib_location = path
+                break
+
 if lib_location is None:
-    raise Exception(
-        'Could not find Opus library. Make sure it is installed.')
+    raise Exception("Could not find Opus library. Make sure it is installed.")
 
 libopus = ctypes.CDLL(lib_location)
 


### PR DESCRIPTION
I was having an issue with this library working in a Debian container. Seems the locations where you would usually search in a Docker container aren't found by default in the original ctypes (probably why there's additional handling in the __init__.py) 

anyways this should make the library more compatible.